### PR TITLE
Refactor RemoveSchedule method in ScheduleController

### DIFF
--- a/PublicTransportApi/PublicTransportApi/Controllers/ScheduleController.cs
+++ b/PublicTransportApi/PublicTransportApi/Controllers/ScheduleController.cs
@@ -47,7 +47,7 @@ public class ScheduleController : ControllerBase
     }
 
     [HttpDelete]
-    public async Task<ActionResult<Result<ScheduleEntry>>> RemoveSchedule([FromQuery] int id)
+    public async Task<ActionResult<Result>> RemoveSchedule([FromQuery] int id)
     {
         var serviceResult = await _scheduleService.RemoveSchedule(id);
 


### PR DESCRIPTION
The type of the action result returned by the 'RemoveSchedule' method in 'ScheduleController.cs' was changed. Now it returns 'Result' instead of 'Result<ScheduleEntry>', making it more generic and adaptable to further changes.