### PR TITLE
Add method to get StopPointLineCorrelation by ID

### DIFF
--- a/PublicTransportApi/PublicTransportApi/Controllers/SPLController.cs
+++ b/PublicTransportApi/PublicTransportApi/Controllers/SPLController.cs
@@ -32,6 +32,20 @@ public class SPLController : ControllerBase
 
         return BadRequest(result);
     }
+    
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<Result<StopPointLineCorrelation>>> GetSplById(int id)
+    {
+        var result = await _splService.GetSPLById(id);
+
+        if (result.IsSuccess)
+        {
+            return Ok(result);
+        }
+
+        return BadRequest(result);
+    }
+
 
     [HttpPost]
     public async Task<ActionResult<Result<StopPointLineCorrelation>>> AddSPL([FromBody] SPLDTO splDto)

--- a/PublicTransportApi/PublicTransportApi/Services/Interfaces/ISPLService.cs
+++ b/PublicTransportApi/PublicTransportApi/Services/Interfaces/ISPLService.cs
@@ -6,6 +6,7 @@ namespace PublicTransportApi.Services.Interfaces;
 public interface ISPLService
 {
     Task<Result<List<StopPointLineCorrelation>>> GetAllSPL();
+    Task<Result<StopPointLineCorrelation>> GetSPLById(int id);
     Task<Result<StopPointLineCorrelation>> AddSPL(SPLDTO splDto);
     Task<Result> DeleteSPL(int id);
     Task<Result<StopPointLineCorrelation>> UpdateSPL(int id, SPLDTO splDto);

--- a/PublicTransportApi/PublicTransportApi/Services/SPLService.cs
+++ b/PublicTransportApi/PublicTransportApi/Services/SPLService.cs
@@ -42,6 +42,41 @@ public class SPLService : ISPLService
         }
     }
 
+    public async Task<Result<StopPointLineCorrelation>> GetSPLById(int id)
+    {
+        try
+        {
+            var result = await _applicationDbContext.StopPointLineCorrelations
+                .Include(spl => spl.Line)
+                .Include(spl => spl.StopPoint)
+                .Include(spl => spl.ScheduleEntries)
+                .FirstOrDefaultAsync(spl => spl.Id.Equals(id));
+
+            if (result is null)
+            {
+                return new Result<StopPointLineCorrelation>
+                {
+                    IsSuccess = false,
+                    Message = ErrorMessages.SPL_SPLNotFound
+                };
+            }
+            
+            return new Result<StopPointLineCorrelation>
+            {
+                IsSuccess = true,
+                Data = result
+            };
+        }
+        catch (Exception)
+        {
+            return new Result<StopPointLineCorrelation>
+            {
+                IsSuccess = false,
+                Message = ErrorMessages.Generic_ExceptionOccured
+            };
+        }
+    }
+
     public async Task<Result<StopPointLineCorrelation>> AddSPL(SPLDTO splDto)
     {
         try


### PR DESCRIPTION
A new method has been implemented to fetch a StopPointLineCorrelation object using its ID in ISPLService and SPLService. Also, corresponding changes have been made to SPLController to ensure API endpoint functionality. This new feature will enable fetching of specific StopPointLineCorrelation data as per requirements, enhancing data accessibility.