### PR TITLE
Add method to update schedule with SPL correlation

### DIFF
--- a/PublicTransportApi/PublicTransportApi/Controllers/ScheduleController.cs
+++ b/PublicTransportApi/PublicTransportApi/Controllers/ScheduleController.cs
@@ -85,4 +85,17 @@ public class ScheduleController : ControllerBase
 
         return new OkObjectResult(serviceResult);
     }
+    
+    [HttpPatch("{scheduleId:int}")]
+    public async Task<ActionResult<Result<ScheduleEntry>>> UpdateSchedule(int scheduleId, [FromQuery] int splId)
+    {
+        var serviceResult = await _scheduleService.AttachToSPL(scheduleId, splId);
+
+        if (!serviceResult.IsSuccess)
+        {
+            return new BadRequestObjectResult(serviceResult);
+        }
+
+        return new OkObjectResult(serviceResult);
+    }
 }

--- a/PublicTransportApi/PublicTransportApi/Services/Interfaces/IScheduleEntryService.cs
+++ b/PublicTransportApi/PublicTransportApi/Services/Interfaces/IScheduleEntryService.cs
@@ -6,6 +6,7 @@ namespace PublicTransportApi.Services.Interfaces;
 public interface IScheduleEntryService
 {
     Task<Result<ScheduleEntry>> AddSchedule(ScheduleEntryDTO scheduleEntryDTO);
+    Task<Result<ScheduleEntry>> AttachToSPL(int scheduleId, int splId);
     Task<Result<List<ScheduleEntry>>> GetAllSchedules();
     Task<Result<ScheduleEntry>> GetScheduleById(int id);
     Task<Result> RemoveSchedule(int id);


### PR DESCRIPTION
A new method has been added in the ScheduleService and its interface to facilitate attaching a Schedule to an SPL (Stop Point Line Correlation). This also includes the necessary HTTP PATCH route in the ScheduleController. Schedule retrieval now includes SPL correlation data.